### PR TITLE
Added location and club to the distinct, since they are in the ordered by

### DIFF
--- a/backend/datalayer/event.py
+++ b/backend/datalayer/event.py
@@ -271,14 +271,12 @@ class EventDataLayer(DataLayer):
             return unexpired_events
 
     def get_all_locations(self):
-        """
-        Returns all locations of active events.
-        """
         with app.app_context():
             current_time = datetime.now()
             locations = (
                 db.session.query(Event.location)
-                .filter(Event.location != "", Event.end_time > current_time)
+                .filter(Event.location != "")
+                .filter(Event.end_time > current_time)
                 .distinct()
                 .order_by(func.lower(Event.location))
                 .all()
@@ -286,16 +284,14 @@ class EventDataLayer(DataLayer):
             return [loc[0] for loc in locations]
 
     def get_all_clubs(self):
-        """
-        Returns all clubs of active events.
-        """
         with app.app_context():
             current_time = datetime.now()
             clubs = (
                 db.session.query(Event.club)
-                .filter(Event.club != "", Event.end_time > current_time)
-                .order_by(func.lower(Event.club))
+                .filter(Event.club != "")
+                .filter(Event.end_time > current_time)
                 .distinct()
+                .order_by(func.lower(Event.club))
                 .all()
             )
             return [club[0] for club in clubs]


### PR DESCRIPTION
Quick fix for the location and club filter options not showing up. This was the error I saw when I called the backend through postman:

```
{
    "error": "Failed to get all clubs",
    "error message": "(psycopg2.errors.InvalidColumnReference) for SELECT DISTINCT, ORDER BY expressions must appear in select list\nLINE 3: ... '2023-11-14T02:05:56.429953'::timestamp ORDER BY lower(even...\n                                                             ^\n\n[SQL: SELECT DISTINCT event.club AS event_club \nFROM event \nWHERE event.club != %(club_1)s AND event.end_time > %(end_time_1)s ORDER BY lower(event.club)]\n[parameters: {'club_1': '', 'end_time_1': datetime.datetime(2023, 11, 14, 2, 5, 56, 429953)}]\n(Background on this error at: https://sqlalche.me/e/20/f405)"
}
```