### PR TITLE
Changed backend sort by start time to date to match with frontend

### DIFF
--- a/backend/datalayer/event.py
+++ b/backend/datalayer/event.py
@@ -474,7 +474,7 @@ class EventDataLayer(DataLayer):
             # Add sorting logic if sortby is provided
             if sort_by == "alphabetical":
                 query = query.order_by(func.lower(Event.title))
-            elif sort_by == "start time":
+            elif sort_by == "date":
                 query = query.order_by(Event.start_time)
             elif sort_by == "trending":
                 query = query.order_by(Event.like_count.desc())

--- a/backend/tests/test_datalayer_event.py
+++ b/backend/tests/test_datalayer_event.py
@@ -1243,7 +1243,7 @@ def test_search_filter_sort(test_client):
 
     # keyword, and date sorting
     try:
-        events = event.search_filter_sort(keyword="Ev", sort_by="start time")
+        events = event.search_filter_sort(keyword="Ev", sort_by="date")
     except (ValueError, TypeError) as error:
         logging.debug(f"Error: {error}")
         assert error == None


### PR DESCRIPTION
We had changed the frontend sortby from Start Time to Date so we need to also change this in the backend as it was previously looking for "start time".
All python tests pass.